### PR TITLE
Changes to add a filter to the deployment targets

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -34,7 +34,7 @@
 
 # Then, deploy our Telegraf agents to the nodes in the `host_inventory` that was passed in
 - name: Install/configure telegraf agents
-  hosts: telegraf
+  hosts: telegraf:&telegraf_nodes
   gather_facts: no
   vars_files:
     - vars/telegraf.yml

--- a/tasks/install-telegraf.yml
+++ b/tasks/install-telegraf.yml
@@ -50,4 +50,4 @@
     environment: "{{environment_vars}}"
     when: update_from_url
   become: true
-  when: (update_from_dir is defined and (local_telegraf_file | basename) == 'telegraf') or (update_from_url is defined and (telegraf_url | basename) == 'telegraf')
+  when: (update_from_dir is defined and ((local_telegraf_file | default('')) | basename) == 'telegraf') or (update_from_url is defined and ((telegraf_url | default('')) | basename) == 'telegraf')


### PR DESCRIPTION
The changes in this pull request take advantage of the second host group that was added to the `build-app-host-groups` role recently to filter out any members of the `telegraf` group that were not part of the `host_inventory` that was passed into the ansible-playbook run.

This is especially critical if we are using a static inventory file that includes a `telegraf` host group but where we only want to deploy Telegraf agents to a subset of those nodes in a single `ansible-playbook` run. With these changes in place, only the targeted nodes will be involved in the deployment, regardless of what the host group in the inventory file that is passed in might say.

Finally, this pull request includes a small bug fix to the `tasks/install-telegraf.yml` task file that was preventing the binary from downloading from a URL when a URL to a custom telegraf binary was passed in.