### PR TITLE
Deploy Telegraf agents to nodes in a non-telegraf host group

### DIFF
--- a/docs/Deployment-Scenarios.md
+++ b/docs/Deployment-Scenarios.md
@@ -21,7 +21,7 @@ $ cat combined-inventory
 192.168.34.9
 192.168.34.10
 
-[telegraf]
+[zookeeper]
 192.168.34.18
 192.168.34.19
 192.168.34.20
@@ -32,7 +32,7 @@ To deploy Telegraf agents to the three nodes in our static inventory file, we'd 
 
 ```bash
 $ ansible-playbook -i combined-inventory -e "{ \
-      data_iface: eth0, \
+      application: zookeeper, data_iface: eth0, \
       telegraf_url: 'http://192.168.34.254/telegraf/linux_amd64/telegraf' \
       yum_repo_url: 'http://192.168.34.254/centos' \
     }" provision-telegraf.yml
@@ -41,6 +41,7 @@ $ ansible-playbook -i combined-inventory -e "{ \
 Alternatively, rather than passing all of those arguments in on the command-line as extra variables, we can make use of the *local variables file* support that is built into this playbook and construct a YAML file that looks something like this containing the configuration parameters that are being used for this deployment:
 
 ```yaml
+application: zookeeper
 data_iface: eth0
 telegraf_url: 'http://192.168.34.254/telegraf/linux_amd64/telegraf'
 yum_repo_url: 'http://192.168.34.254/centos'

--- a/docs/Dynamic-vs-Static-Inventory.md
+++ b/docs/Dynamic-vs-Static-Inventory.md
@@ -22,14 +22,14 @@ $ cat combined-inventory
 192.168.34.9
 192.168.34.10
 
-[telegraf]
+[zookeeper]
 192.168.34.18
 192.168.34.19
 192.168.34.20
 
 ```
 
-As you can see, our static inventory file consists of a list of the hosts targeted by our deployment followed by two host groups (the `telegraf` and `kafka` host groups). For each host in this file, we provide a list of the parameters that Ansible will need to connect to that host (INI-file style) as a set of `name=value` pairs. In this example, we've defined the following values for each of the entries in our static inventory file:
+As you can see, our static inventory file consists of a list of the hosts targeted by our deployment followed by two host groups (the `zookeeper` and `kafka` host groups in this example). For each host in this file, we provide a list of the parameters that Ansible will need to connect to that host (INI-file style) as a set of `name=value` pairs. In this example, we've defined the following values for each of the entries in our static inventory file:
 
 * **`ansible_ssh_host`**: the hostname/address that Ansible should use to connect to that host; if not specified, the same hostname/address listed at the start of the line for that entry for that host will be used (in this example we are using IP addresses). This parameter can be important when there are multiple network interfaces on each host and only one of them (an admin network, for example) allows for SSH access
 * **`ansible_ssh_port`**: the port that Ansible should use when connecting to the host via SSH; if not specified, Ansible will attempt to connect using the default SSH port (port 22)

--- a/provision-telegraf.yml
+++ b/provision-telegraf.yml
@@ -6,23 +6,30 @@
 - name: Create telegraf and kafka host groups
   hosts: localhost
   gather_facts: no
+  vars_files:
+    - vars/telegraf.yml
   tasks:
+    # always load the 'local variables file', if one was defined, to get any
+    # variables we might need from that file when constructing our host groups
+    - name: Load local variables file
+      include_vars:
+        file: "{{local_vars_file}}"
+      when: not (local_vars_file is undefined or local_vars_file is none or local_vars_file | trim == '')
+    # regardless of whether the `application` value is still set to the default
+    # `telegraf` value from the `vars/telegraf.yml` file or was reset in the
+    # input `local_vars_file` (above), set a fact for the `localhost` so that
+    # we can use it in our third play (below) to define the target hosts that
+    # we are provisioning with Telegraf agents to using this playbook
+    - set_fact:
+        application: "{{application}}"
     # if we're using dynamic provisioning; build the host groups from the
     # meta-data associated with the matching nodes in the selected cloud
-    - block:
-      # load the 'local variables file', if one was defined, to get any variables
-      # we might need from that file when constructing our host groups
-      - name: Load local variables file
-        include_vars:
-          file: "{{local_vars_file}}"
-        when: not (local_vars_file is undefined or local_vars_file is none or local_vars_file | trim == '')
-      # then, build our host groups
-      - include_role:
-          name: build-app-host-groups
-        vars:
-          host_group_list:
-            - { name: "{{application}}", as_name: telegraf }
-            - name: kafka
+    - include_role:
+        name: build-app-host-groups
+      vars:
+        host_group_list:
+          - { name: "{{application}}" }
+          - name: kafka
       when: cloud is defined and (cloud == 'aws' or cloud == 'osp')
 
 # Collect the 'hostvars' facts from the kafka host group
@@ -30,9 +37,11 @@
   hosts: kafka
   tasks: []
 
-# Then, deploy our Telegraf agents to the nodes in the `host_inventory` that was passed in
+# Then, deploy our Telegraf agents to the nodes in the application host group
+# that was passed in (or 'the 'telegraf' host group if a separate `application`
+# target wasn't defined in the local variables file)
 - name: Install/configure telegraf agents
-  hosts: telegraf
+  hosts: "{{hostvars['localhost']['application']}}"
   gather_facts: no
   vars_files:
     - vars/telegraf.yml
@@ -65,7 +74,7 @@
         iface_descriptions: "{{iface_description_array}}"
       when: not (iface_description_array is undefined or iface_description_array == [])
     # and now that we know we have our data_iface identified, we can construct
-    # the list of zk_nodes (the data_iface IP addresses of our kafka_nodes)
+    # the list of kfka_nodes (the data_iface IP addresses of our kafka_nodes)
     - set_fact:
         kfka_nodes: "{{(kafka_nodes | default([])) | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
     # if we're provisioning a RHEL machine, then we need to ensure that


### PR DESCRIPTION
The changes in this pull request add support for deployment of Telegraf agents to nodes in a non-Telegraf host group. With the changes in this pull request in place, a static host group that looks like this:

```bash
$ cat combined-inventory
# example combined inventory file for clustered deployment

192.168.34.8 ansible_ssh_host=192.168.34.8 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/kafka_cluster_private_key'
192.168.34.9 ansible_ssh_host=192.168.34.9 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/kafka_cluster_private_key'
192.168.34.10 ansible_ssh_host=192.168.34.10 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/kafka_cluster_private_key'
192.168.34.18 ansible_ssh_host=192.168.34.18 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'
192.168.34.19 ansible_ssh_host=192.168.34.19 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'
192.168.34.20 ansible_ssh_host=192.168.34.20 ansible_ssh_port=22 ansible_ssh_user='cloud-user' ansible_ssh_private_key_file='keys/zk_cluster_private_key'

[kafka]
192.168.34.8
192.168.34.9
192.168.34.10

[zookeeper]
192.168.34.18
192.168.34.19
192.168.34.20

```

can be used as the input inventory to an `ansible-playbook` run that looks like this:

```
$ ./provision-telegraf.yml -i kafka_inventory -e "{ local_vars_file: './test.yml' }"
```

where the local variables file that is passed in, above (`test.yml`) looks like this:

```yaml
---
application: zookeeper
data_iface: eth1
local_telegraf_file: '/Users/tjmcs/src/go/bin/linux_amd64/telegraf'
```

Note that in this example, the `application` target for the playbook run is being re-defined in the local variables file to be the nodes in the `zookeeper` host group from the static inventory file that is being passed into the playbook run (above).

The changes made in this PR should work equally well for both the static and dynamic inventory use cases, so a command like the following should deploy Telegraf agents to all of the `kafka` nodes in an AWS environment:

```bash
$ AWS_PROFILE=datanexus_west ansible-playbook -e "{ \
        application: zookeeper, cloud: aws, \
        tenant: labs, project: projectx, domain: preprod, \
        private_key_path: './keys', data_iface: eth0 \
    }" provision-telegraf.yml
```

Our assumption here is that the configuration of the Telegraf agents being deployed to nodes with different applications running on them is likely to change, so nodes with a similar `application` tag are most likely to be configured similarly (and be the target of a given `ansible-playbook` run). By simply changing the application tag that is targeted by a playbook run (either using an extra variable or using a local variables file) it is quite simple to target a different set of application nodes in a given playbook run.

It should also be noted here that if the application tag is not redefined (either by passing a value for the `application` tag using extra variable or by setting a value for that tag in a local variables file), then the default application tag value that is defined in the `vars/telegraf.yml` file (`telegraf`) will be used to determine the host group that should be targeted by the playbook run (i.e. hosts in the `telegraf` host group will be targeted by default).